### PR TITLE
CMakeListst.txt: Add include path for tbb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ include_directories(
   ${TBB_INCLUDE_DIR} # Allow for extra include paths (ios builds tbb in 3rdparty)
   /opt/local/include # Make sure we can find tbb with Mac + Macports
   /usr/local/include # Make sure we can find tbb with Mac + Homebrew
+  /opt/homebrew/include # Make sure we can find tbb with Mac + Homebrew + M1
 )
 
 if (INSTANT_MESHES_DEV_MODE)


### PR DESCRIPTION
Add include path so tbb can be found on computers with homebrew in /opt/homebrew/